### PR TITLE
Add movie playback and audio hotfix

### DIFF
--- a/assets_py_unpacker/lib/unpack_video.py
+++ b/assets_py_unpacker/lib/unpack_video.py
@@ -15,22 +15,52 @@ def mp4_to_ogv_pool(paths_mp4 : List[str], command_ffmpeg : str = "ffmpeg", qual
 
     pool : List[Popen] = []
     path_pool : List[str] = []
+    png_done : List[bool] = []
 
     paths_successful : List[str] = []
 
     printer = OneLinePrinter()
     printer.print("Converting cutscene videos...")
 
-    ffmpeg_inputs = list(paths_mp4)
-    while len(ffmpeg_inputs) > 0:
+    def clean_pool():
         for idx in range(len(pool) - 1, -1, -1):
             if not(pool[idx].poll() is None):
                 if pool[idx].wait() == 0:
-                    paths_successful.append(path_pool[idx])
-                    printer.print("Converting videos, ~%d/%d" % (len(paths_successful), len(paths_mp4)))
+                    # Godot has some limitations with video playback, LT2R holds the last frame which Godot cannot
+                    #     do (and we can't find the last frame anyway because stream length is not implemented!)
+                    # Reuse pool after video completed to convert the last frame out as a PNG for later.
 
-                pool.pop(idx)
-                path_pool.pop(idx)
+                    # If PNG was done, we're actually done
+                    if png_done[idx]:
+                        paths_successful.append(path_pool[idx])
+                        printer.print("Converting videos, ~%d/%d" % (len(paths_successful), len(paths_mp4)))
+                        pool.pop(idx)
+                        path_pool.pop(idx)
+                        png_done.pop(idx)
+                    else:
+                        # Else, replace this process with one that converts the PNG and continue
+                        path_ogv = splitext(path_pool[idx])[0] + ".ogv"
+                        path_png = splitext(path_pool[idx])[0] + ".png"
+
+                        png_done[idx] = True
+
+                        if not(exists(path_png)):
+                            process = (ffmpeg
+                                       .input(path_ogv, sseof=-1)
+                                       .output(path_png, an=None, loglevel="quiet", **{'update': 1})
+                                       .run_async(cmd=command_ffmpeg)
+                                       )
+
+                            pool[idx] = process
+                else:
+                    # If conversion failed, remove from pool
+                    pool.pop(idx)
+                    path_pool.pop(idx)
+                    png_done.pop(idx)
+
+    ffmpeg_inputs = list(paths_mp4)
+    while len(ffmpeg_inputs) > 0:
+        clean_pool()
 
         if len(pool) >= max_thread_count:
             sleep(0.01)
@@ -51,16 +81,10 @@ def mp4_to_ogv_pool(paths_mp4 : List[str], command_ffmpeg : str = "ffmpeg", qual
             
             pool.append(process)
             path_pool.append(path_input)
+            png_done.append(False)
     
     while len(pool) > 0:
-        for idx in range(len(pool) - 1, -1, -1):
-            if not(pool[idx].poll() is None):
-                if pool[idx].wait() == 0:
-                    paths_successful.append(path_pool[idx])
-                    printer.print("Converting videos, ~%d/%d" % (len(paths_successful), len(paths_mp4)))
-
-                pool.pop(idx)
-                path_pool.pop(idx)
+        clean_pool()
         sleep(0.01)
     
     printer.print("Converted videos, %d/%d!" % (len(paths_successful), len(paths_mp4)))

--- a/godot/gamemodes/gamemode_movie.gd
+++ b/godot/gamemodes/gamemode_movie.gd
@@ -1,6 +1,47 @@
 extends Lt2GamemodeBaseClass
 
+@onready var _node_player : VideoStreamPlayer = get_node("player")
+@onready var _node_texture : TextureRect = get_node("workaround_end_frame")
+
+# REF - MovieObject.PlayMovie
+# TODO - Buttons, rotation, mode detection (few flags)
+# TODO - OGV weird edge bug, video seems slightly scaled with stretched artifact at edge?
+#            Is this a Godot problem?
+
 func _ready():
-	# TODO - Movie
+	node_screen_controller.canvas_resize.connect(_on_resize)
+	_node_player.finished.connect(_on_end)
+	
+	node_screen_controller.configure_fullscreen()
+	await node_screen_controller.fade_in_async(0)
+	_on_resize()
+	
+	var stream = load(Lt2Utils.get_asset_path("movie/m%d.ogv" % obj_state.id_movie))
+	if stream == null:
+		_on_end()
+		return
+		
+	_node_texture.texture = load(Lt2Utils.get_asset_path("movie/m%d.png" % obj_state.id_movie))
+	
+	_node_player.stream = stream
+	_node_player.expand = true
+	
+	SoundController.play_cutscene_audio(obj_state.id_movie)
+	_node_player.play()
+
+func _on_end():
+	SoundController.stop_sample_sfx()
+	await node_screen_controller.fade_out_async(1.0)
+	
+	node_screen_controller.configure_room_mode()
 	obj_state.set_gamemode(obj_state.get_gamemode_next())
 	completed.emit()
+
+func _on_resize():
+	_node_player.size.x = node_screen_controller.get_size_bs().x
+	_node_player.size.y = _node_player.size.x * (9.0/16.0)
+	_node_player.position.x = node_screen_controller.get_anchor_loc_bs().x
+	_node_player.position.y = node_screen_controller.get_anchor_loc_bs().y + (node_screen_controller.get_size_bs().y - _node_player.size.y) / 2
+	
+	_node_texture.position = _node_player.position
+	_node_texture.size = _node_player.size

--- a/godot/gamemodes/gamemode_movie.tscn
+++ b/godot/gamemodes/gamemode_movie.tscn
@@ -4,3 +4,12 @@
 
 [node name="gamemode_movie" type="Node2D"]
 script = ExtResource("1_8g577")
+
+[node name="workaround_end_frame" type="TextureRect" parent="."]
+offset_right = 40.0
+offset_bottom = 40.0
+expand_mode = 2
+
+[node name="player" type="VideoStreamPlayer" parent="."]
+offset_right = 40.0
+offset_bottom = 40.0

--- a/godot/scripts/sound_controller.gd
+++ b/godot/scripts/sound_controller.gd
@@ -15,6 +15,7 @@ extends Node
 # level functions to middleware which is mimicked here.
 
 # TODO - 2_Sound_SE_Play_Preresolved_ID
+# TODO - lt2SoundObject.SND_Process
 
 class CriMonophonicChannel:
 	extends Node2D
@@ -79,8 +80,10 @@ class CriMonophonicChannel:
 			loop = true
 		
 		channel.stream = audio
-		channel.stream.loop = loop
-		channel.stream.loop_offset = loop_base
+		
+		if channel.stream != null:
+			channel.stream.loop = loop
+			channel.stream.loop_offset = loop_base
 		
 		if start_now:
 			channel.play()
@@ -267,7 +270,27 @@ func fade_bgm_2(target_vol : float, duration : float):
 func play_sample_sfx(id : int):
 	_node_audio_sample.stop()
 	_node_audio_sample.stream = Lt2Utils.get_sample_audio_from_sfx_id(id)
+	_node_audio_sample.stream_paused = false
 	_node_audio_sample.play()
+
+func play_cutscene_audio(id : int):
+	# TODO - This is a workaround since we're not implementing the full set of sound features
+	#        Probably is meant to override stream audio channel, REF - lt2CSndStream.__Update
+	var path_sfx = Lt2Utils.get_asset_path("sound/m%d.ogg" % id)
+	_node_audio_sample.stream = load(path_sfx)
+	_node_audio_sample.stream_paused = false
+	_node_audio_sample.play()
+
+func pause_sample_sfx():
+	# Workaround, LT2R seeks to the time instead which we're not going to do...
+	# REF - MovieObject.PlayMovie
+	_node_audio_sample.stream_paused = true
+
+func resume_sample_sfx():
+	_node_audio_sample.stream_paused = false
+
+func stop_sample_sfx():
+	_node_audio_sample.stop()
 
 func play_preresolved_synth_sfx(id : int, audio : AudioStream, allow_overlap : bool = false):
 	if id >= 200:


### PR DESCRIPTION
Slight changes to asset extractor to generate final frame as well as video but otherwise self-explanatory implementation of Movie mode. This includes a hotfix for audio playback to fix null referencing when audio is missing. This can be encountered early when the intro sequence attempts to load BG0 (intentionally empty) and crashes.